### PR TITLE
feat: add typed relationship navigation via fields()

### DIFF
--- a/src/zen.ts
+++ b/src/zen.ts
@@ -28,6 +28,8 @@ export {
 	type Infer,
 	type FieldMeta,
 	type FieldType,
+	type Relation,
+	type InferRefs,
 } from "./impl/table.js";
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Enable type-safe navigation through table references via `fields()`
- Auto-infer relationship types from schema using phantom/branded types
- Works with optional/nullable FK fields
- Preserves types through `pick()` and `derive()` transformations
- Adds collision detection for duplicate reference aliases

## Usage

```typescript
const Orgs = table("orgs", {
  id: z.string().uuid().db.primary(),
  name: z.string(),
});

const Users = table("users", {
  id: z.string().uuid().db.primary(),
  orgId: z.string().uuid().db.references(Orgs, "org"),
  name: z.string(),
});

const Posts = table("posts", {
  id: z.string().uuid().db.primary(),
  authorId: z.string().uuid().db.references(Users, "author"),
  title: z.string(),
});

// Type-safe navigation
Posts.fields().title                          // FieldMeta
Posts.fields().author                         // Relation<typeof Users>
Posts.fields().author.fields()                // { id, orgId, name, org }
Posts.fields().author.fields().org.fields()   // { id, name }

// pick() correctly narrows refs
Posts.pick('id', 'title').fields().author     // ❌ Type error - author not available
Posts.pick('id', 'authorId').fields().author  // ✅ Works
```

## Test plan

- [x] All 510 existing tests pass
- [x] TypeScript type checking passes
- [x] ESLint passes
- [x] Verified pick() correctly filters refs when FK column excluded
- [x] Verified optional/nullable FK fields work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)