### PR TITLE
Better introspection of table relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ const post = await db.get(Posts, posts[0].id);
 await db.update(Users, {name: "Alice Smith"}, user.id);
 ```
 
-## Why Zen?
+## Why ZenDB?
 
 Zen is the missing link between SQL and typed data. By writing tables with Zod schema, you get idempotent migration helpers, typed CRUD, normalized object references, and many features other database clients cannot provide.
 
@@ -829,15 +829,17 @@ type NewUser = Insert<typeof Users>; // Insert type (respects defaults/.db.auto(
 
 ## Field Metadata
 
-Tables expose metadata for form generation:
+Tables expose metadata for introspection and form generation:
 
 ```typescript
 const fields = Users.fields();
-// {
-//   email: { name: "email", type: "email", required: true, unique: true },
-//   name: { name: "name", type: "text", required: true, maxLength: 100 },
-//   role: { name: "role", type: "select", options: ["user", "admin"], default: "user" },
-// }
+
+// Preferred: raw schema and db metadata
+fields.email.name;              // "email"
+fields.email.schema;            // ZodString - use Zod APIs (isOptional(), etc.)
+fields.email.db;                // FieldDBMeta object
+fields.email.db.unique;         // true
+fields.email.db.primaryKey;     // undefined
 
 const pkName = Users.meta.primary;    // "id" (field name)
 const pkFragment = Users.primary;     // SQLTemplate: "users"."id"
@@ -847,6 +849,9 @@ const refs = Posts.meta.references;   // [{fieldName: "authorId", table: Users, 
 Posts.relations().author.table;       // Users table
 Posts.relations().author.fields();    // Users field metadata
 Users.relations().posts.table;        // Posts table (if reverseAs: "posts" defined)
+
+// Chain navigation through relationships
+Users.relations().posts.fields().author.fields().email;  // Back to Users.email field
 ```
 
 ## Performance
@@ -1042,9 +1047,9 @@ import type {
   CompoundReference, // Compound foreign key reference
 
   // Field types
-  FieldMeta,         // Field metadata for form generation
-  FieldType,         // Field type enum
+  FieldMeta,         // Field metadata for introspection
   FieldDBMeta,       // Database-specific field metadata
+  Relation,          // Relation navigator from table.relations()
 
   // Type inference
   Row,               // Infer row type from Table (after read)

--- a/README.md
+++ b/README.md
@@ -839,9 +839,14 @@ const fields = Users.fields();
 //   role: { name: "role", type: "select", options: ["user", "admin"], default: "user" },
 // }
 
-const pkName = Users.primaryKey();    // "id" (field name)
+const pkName = Users.meta.primary;    // "id" (field name)
 const pkFragment = Users.primary;     // SQLTemplate: "users"."id"
-const refs = Posts.references();      // [{fieldName: "authorId", table: Users, as: "author"}]
+const refs = Posts.meta.references;   // [{fieldName: "authorId", table: Users, as: "author"}]
+
+// Relation navigation (forward and reverse)
+Posts.relations().author.table;       // Users table
+Posts.relations().author.fields();    // Users field metadata
+Users.relations().posts.table;        // Posts table (if reverseAs: "posts" defined)
 ```
 
 ## Performance
@@ -1094,10 +1099,9 @@ Users.primary;                 // SQLTemplate for primary key column
 // Metadata
 Users.name;                    // Table name string
 Users.schema;                  // Zod schema
-Users.meta;                    // Table metadata (primary, indexes, etc.)
-Users.primaryKey();            // Primary key field name or null
+Users.meta;                    // Table metadata (primary, references, indexes, etc.)
 Users.fields();                // Field metadata for form generation
-Users.references();            // Foreign key references
+Users.relations();             // Forward and reverse relation navigators
 
 // Derived Tables
 Users.pick("id", "email");     // PartialTable with subset of fields

--- a/src/impl/table.ts
+++ b/src/impl/table.ts
@@ -809,38 +809,109 @@ export type FieldType =
 	| "hidden";
 
 export interface FieldMeta {
-	// Field identity
+	// =========================================================================
+	// Raw schema access (preferred)
+	// =========================================================================
+
+	/** Field name (the key in the schema) */
 	name: string;
+
+	/** Raw Zod schema - use Zod APIs for introspection (isOptional(), etc.) */
+	schema: z.ZodType;
+
+	/** Raw database metadata from .db.*() methods */
+	db: FieldDBMeta;
+
+	// =========================================================================
+	// Deprecated: cooked properties for backwards compatibility
+	// These will be removed in a future major version.
+	// Use `schema` and `db` properties instead.
+	// =========================================================================
+
+	/**
+	 * @deprecated Use `schema` with Zod APIs instead. This form-specific type
+	 * inference will move to a separate @b9g/forms package.
+	 */
 	type: FieldType;
+
+	/**
+	 * @deprecated Use `!schema.isOptional() && !db.autoIncrement && !db.inserted` instead.
+	 */
 	required: boolean;
 
-	// From .db.*() methods
+	/**
+	 * @deprecated Use `db.primaryKey` instead.
+	 */
 	primaryKey?: boolean;
+
+	/**
+	 * @deprecated Use `db.unique` instead.
+	 */
 	unique?: boolean;
+
+	/**
+	 * @deprecated Use `db.indexed` instead.
+	 */
 	indexed?: boolean;
+
+	/**
+	 * @deprecated Use `db.softDelete` instead.
+	 */
 	softDelete?: boolean;
+
+	/**
+	 * @deprecated Use `db.reference` instead.
+	 */
 	reference?: {
 		table: Table;
 		field: string;
 		as: string;
 		onDelete?: "cascade" | "set null" | "restrict";
 	};
+
+	/**
+	 * @deprecated Use `db.encode` instead.
+	 */
 	encode?: (value: any) => any;
+
+	/**
+	 * @deprecated Use `db.decode` instead.
+	 */
 	decode?: (value: any) => any;
+
+	/**
+	 * @deprecated Use `db.columnType` instead.
+	 */
 	columnType?: string;
+
+	/**
+	 * @deprecated Use `db.autoIncrement` instead.
+	 */
 	autoIncrement?: boolean;
+
+	/**
+	 * @deprecated Use `db.inserted` instead.
+	 */
 	inserted?: {
 		type: "sql" | "symbol" | "function";
 		template?: SQLTemplate;
 		symbol?: SQLBuiltin;
 		fn?: () => unknown;
 	};
+
+	/**
+	 * @deprecated Use `db.updated` instead.
+	 */
 	updated?: {
 		type: "sql" | "symbol" | "function";
 		template?: SQLTemplate;
 		symbol?: SQLBuiltin;
 		fn?: () => unknown;
 	};
+
+	/**
+	 * @deprecated Use `db.upserted` instead.
+	 */
 	upserted?: {
 		type: "sql" | "symbol" | "function";
 		template?: SQLTemplate;
@@ -848,12 +919,34 @@ export interface FieldMeta {
 		fn?: () => unknown;
 	};
 
-	// From Zod schema
+	/**
+	 * @deprecated Extract from Zod schema directly.
+	 */
 	default?: unknown;
+
+	/**
+	 * @deprecated Extract from Zod schema directly.
+	 */
 	maxLength?: number;
+
+	/**
+	 * @deprecated Extract from Zod schema directly.
+	 */
 	minLength?: number;
+
+	/**
+	 * @deprecated Extract from Zod schema directly.
+	 */
 	min?: number;
+
+	/**
+	 * @deprecated Extract from Zod schema directly.
+	 */
 	max?: number;
+
+	/**
+	 * @deprecated Extract from Zod schema directly (for ZodEnum).
+	 */
 	options?: readonly string[];
 
 	/** Additional user-defined metadata from Zod's .meta() (label, helpText, widget, etc.) */
@@ -2424,13 +2517,18 @@ function extractFieldMeta(
 	const {db: _db, ...userMeta} = collectedMeta;
 
 	const meta: FieldMeta = {
+		// New: raw schema access (preferred)
 		name,
+		schema: zodType,
+		db: dbMeta,
+
+		// Deprecated: cooked properties for backwards compatibility
 		type: "text",
 		required: !isOptional && !isNullable && !hasDefault,
 		...userMeta, // Spread user-defined metadata (label, helpText, widget, etc.)
 	};
 
-	// Apply database metadata - merge all FieldDBMeta properties
+	// Apply database metadata - merge all FieldDBMeta properties (deprecated, use meta.db instead)
 	if (dbMeta.primaryKey) meta.primaryKey = true;
 	if (dbMeta.unique) meta.unique = true;
 	if (dbMeta.indexed) meta.indexed = true;

--- a/test/normalize.test.ts
+++ b/test/normalize.test.ts
@@ -1377,7 +1377,7 @@ describe("enumerability and serialization", () => {
 			id: z.string().db.primary(),
 			title: z.string(),
 			authorId: z.string().db.references(users, "author", {
-				reverseAs: "posts",
+				reverseAs: "derivedPosts",
 			}),
 		},
 		{
@@ -1688,7 +1688,7 @@ describe("enumerability and serialization", () => {
 			id: z.string().db.primary(),
 			title: z.string(),
 			authorId: z.string().nullable().db.references(users, "author", {
-				reverseAs: "posts",
+				reverseAs: "nullablePosts",
 			}),
 		});
 


### PR DESCRIPTION
## Summary

- Adds `relations()` method to navigate both forward and reverse table relations
- Uses WeakMap registry with lazy resolution to handle circular references
- Forward relations come from `as`, reverse from `reverseAs`
- Validates uniqueness of relation names per target table

## API

```typescript
const Users = table("users", {
  id: z.string().db.primary(),
  email: z.string().email(),
});

const Posts = table("posts", {
  id: z.string().db.primary(),
  title: z.string(),
  authorId: z.string().db.references(Users, "author", { reverseAs: "posts" }),
});

// Forward relation (many-to-one): Posts -> Users
Posts.relations().author.table           // Users table
Posts.relations().author.fields().email  // Users.email field metadata

// Reverse relation (one-to-many): Users -> Posts
Users.relations().posts.table            // Posts table
Users.relations().posts.fields().title   // Posts.title field metadata

// Chain navigation
Users.relations().posts.fields().author.fields().email  // Back to Users
```

## Relation interface

```typescript
interface Relation<TargetTable> {
  fields(): TableFields<...>;  // Navigate to related table's fields
  table: TargetTable;          // Direct access to related table
}
```

## Test plan

- [x] Returns empty object for table with no relations
- [x] Returns forward relation from references
- [x] Returns reverse relation when defined with `reverseAs`
- [x] Returns both forward and reverse relations
- [x] `fields()` navigates to related table fields
- [x] Supports multiple reverse relations
- [x] Chained navigation through relations
- [x] No reverse relation without `reverseAs`
- [x] Throws on duplicate `reverseAs` names for same target
- [x] Throws when `reverseAs` collides with forward relation name

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)